### PR TITLE
Fixed Android example didn't attach the activity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+* Fixed example
+
 ## 2.1.0
 
 * Change API: `startListenUserConsent` and `startListenRetriever` returns Future

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -44,11 +44,11 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.test_otp_autofill"
+        applicationId "ru.surfstudio.otp_autofill_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 19
-        targetSdkVersion 19
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/kotlin/com/example/test_otp_autofill/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/test_otp_autofill/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.test_otp_autofill
+package ru.surfstudio.otp_autofill_example
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: otp_autofill
-version: 2.1.0
+version: 2.1.1
 description: Android implementation of OTP autofill with using User Consent API and Retriever API. Add possibility to receive OTP code from another input.
 repository: "https://github.com/surfstudio/flutter-otp-autofill"
 issue_tracker: "https://github.com/surfstudio/flutter-otp-autofill/issues"


### PR DESCRIPTION
Increased targetSdkVerison up to 28. Changed package name in MainActivity

Changed applicationId in buildGradle.
Names now match manifest names