### PR TITLE
mark receivers as exported

### DIFF
--- a/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
+++ b/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import androidx.activity.result.IntentSenderRequest.*
 import androidx.annotation.NonNull;
 import com.google.android.gms.auth.api.identity.GetPhoneNumberHintIntentRequest
@@ -201,7 +202,12 @@ class OTPPlugin : FlutterPlugin, MethodCallHandler, PluginRegistry.ActivityResul
         }
 
         val intentFilter = IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION)
-        this.activity?.registerReceiver(smsRetrieverBroadcastReceiver, intentFilter)
+        if(Build.VERSION_CODES.O <= Build.VERSION.SDK_INT) {
+            this.activity?.registerReceiver(smsRetrieverBroadcastReceiver, intentFilter,Context.RECEIVER_EXPORTED)
+        }else {
+
+            this.activity?.registerReceiver(smsRetrieverBroadcastReceiver, intentFilter)
+        }
     }
 
     private fun unRegisterBroadcastReceivers() {


### PR DESCRIPTION
## Related tasks
no tasks

## Changes
with Android 14 android receivers should be either marked as exported or marked not exported.
documentation: 
https://developer.android.com/about/versions/14/behavior-changes-14


## Checklist for self-check
- [x] Commits and PRs have been filed according to [the rules on the project](https://github.com/surfstudio/surf-flutter-app-template#workflow-in-a-repository).
- [ ] The author is marked as an assigne and assigned mandatory reviewers.
- [ ] Required labels marked
- [ ] Specified related tasks and/or related PRs.
- [x] Specified Changes.
- [ ] Attached videos/screenshots demonstrating the fix/feature.
- [ ] All unspecified fields in the PR description deleted.
- [ ] New code covered by tests.

## Checklist for reviewers
- [ ] CI passed successfully _(with a green check mark)_.
- [ ] PR is atomic, by volume no more than 400 (+-) corrected lines (not including codogen).

Design:
- [ ] System design corresponds to the agreements on structure and architecture on the project.
- [ ] The code is decomposed into necessary and sufficient components.

Functionality:
- [x] The code solves the problem.
- [ ] Any changes to the user interface are reasonable and look good.

Complexity:
- [x] The code is clear, easy to read, functions are small, no more than 50 lines.
- [x] The logic is not overcomplicated, there is no overengineering (no code sections that may be needed in the future, but no one knows about it).

Tests:
- [ ] Updated or added tests for mandatory components.
- [ ] The tests are correct, helpful, and well designed/developed.

Naming:
- [x] The naming of variables, methods, classes and other components is understandable.

Comments:
- [x] The comments are understandable and helpful.

Documentation:
- [x] All labels are correct
- [ ] Technical documentation updated (after approval, updates last reviewer). 
