### PR TITLE
fix: Phone Number Hint always returning "403 User denied consent"

### DIFF
--- a/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
+++ b/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
@@ -127,17 +127,18 @@ class OTPPlugin : FlutterPlugin, MethodCallHandler, PluginRegistry.ActivityResul
                 }
 
             credentialPickerRequest -> if (resultCode == Activity.RESULT_OK && data != null) {
-                // Check if the result is for credential picker
-                if (data.hasExtra(SmsRetriever.EXTRA_SMS_MESSAGE)) {
-                    // This is a result from the SMS consent picker
+                try {
                     val phoneNumber =
                         Identity.getSignInClient(context!!).getPhoneNumberFromIntent(data)
                     lastResult?.success(phoneNumber)
                     lastResult = null
-                } else {
-                    lastResult?.error("403", "User denied consent", null)
+                } catch (e: Exception) {
+                    lastResult?.error("500", "Failed to extract phone number: ${e.message}", null)
                     lastResult = null
                 }
+            } else {
+                lastResult?.error("403", "User denied consent", null)
+                lastResult = null
             }
         }
         return true


### PR DESCRIPTION
## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Attached videos/screenshots demonstrating the fix/feature.
- [ ] Have you run the tests locally to confirm they pass?

## Changes

### What is the current behavior, and the steps to reproduce the issue?

When using `getTelephoneHint` to show the Phone Number Hint picker, selecting a phone number always returns a `"403 User denied consent"` error instead of the selected phone number.

This happens because the `credentialPickerRequest` handler in `onActivityResult` checks `data.hasExtra(SmsRetriever.EXTRA_SMS_MESSAGE)` before extracting the phone number. That extra is only present in the **SMS User Consent** flow and is never set in the **Phone Number Hint** flow, so the check always returns `false` and falls into the error branch.

### What is the expected behavior?

Selecting a phone number from the hint picker should successfully return the phone number to the Flutter side via `lastResult?.success(phoneNumber)`.

### How does this PR fix the problem?

- Removed the incorrect `data.hasExtra(SmsRetriever.EXTRA_SMS_MESSAGE)` guard from the `credentialPickerRequest` handler.
- Directly calls `Identity.getSignInClient(context).getPhoneNumberFromIntent(data)` wrapped in a `try/catch` to handle extraction failures gracefully (returns a `"500"` error with the exception message).
- Moved the `"403 User denied consent"` error to the outer `else` branch, where it correctly fires only when the user actually dismisses the picker (`resultCode != RESULT_OK` or `data == null`).

Tap on "Preview" ⤴

And choose one of the templates:

* [Bugfix PR](?expand=1&template=bug_fix.md)
* [New feature PR](?expand=1&template=new_feature.md)
* [Documentation update PR](?expand=1&template=documentation_update.md)
